### PR TITLE
fix: Deprecate Gazenot::new in favor of into_the_abyss

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -105,14 +105,29 @@ struct ListReleasesResponse {
 }
 
 impl Gazenot {
-    /// Gaze Not Into The Abyss, Lest You Become A Release Engineer
+    /// Create a new authenticated client for The Abyss
+    ///
+    /// *Gaze Not Into The Abyss, Lest You Become A Release Engineer*
+    ///
+    /// Authentication requires an Axo Releases Token, whose value
+    /// is currently sourced from an AXO_RELEASES_TOKEN environment variable.
+    /// It's an error for that variable to not be properly set.
     ///
     /// This is the vastly superior alias for [`Gazenot::new`].
+    ///
+    /// See also, [`Gazenot::new_unauthed`].
+    #[doc(alias = "new")]
     pub fn into_the_abyss(
         source_host: impl Into<SourceHost>,
         owner: impl Into<Owner>,
     ) -> Result<Self> {
-        Self::new(source_host, owner)
+        let source_host = source_host.into();
+        let owner = owner.into();
+
+        let auth_headers = auth_headers(&source_host, &owner)
+            .map_err(|e| GazenotError::new("initializing Abyss authentication", e))?;
+
+        Self::new_with_auth_headers(source_host, owner, auth_headers)
     }
 
     /// Create a new authenticated client for The Abyss
@@ -124,14 +139,12 @@ impl Gazenot {
     /// This is the vastly inferior alias for [`Gazenot::into_the_abyss`].
     ///
     /// See also, [`Gazenot::new_unauthed`].
+    #[deprecated(
+        since = "0.1.0",
+        note = "use the vastly superior alias `Gazenot::into_the_abyss`"
+    )]
     pub fn new(source_host: impl Into<SourceHost>, owner: impl Into<Owner>) -> Result<Self> {
-        let source_host = source_host.into();
-        let owner = owner.into();
-
-        let auth_headers = auth_headers(&source_host, &owner)
-            .map_err(|e| GazenotError::new("initializing Abyss authentication", e))?;
-
-        Self::new_with_auth_headers(source_host, owner, auth_headers)
+        Self::into_the_abyss(source_host, owner)
     }
 
     /// Create a new client for The Abyss with no authentication

--- a/src/client.rs
+++ b/src/client.rs
@@ -123,7 +123,7 @@ impl Gazenot {
     ///
     /// This is the vastly inferior alias for [`Gazenot::into_the_abyss`].
     ///
-    /// See also, `[Abyss::new_unauthed][]`.
+    /// See also, [`Gazenot::new_unauthed`].
     pub fn new(source_host: impl Into<SourceHost>, owner: impl Into<Owner>) -> Result<Self> {
         let source_host = source_host.into();
         let owner = owner.into();


### PR DESCRIPTION
`Gazenot::new` is clearly inferior. I believe it should be deprecated in version 0.1.1 and fully removed by version 0.2.0, maybe 0.3.0 if you want to give consumers of this library enough time to prepare. Although I don't believe anyone using the inferior `Gazenot::new` deserves such privilege. Still, we should warn them by first deprecating it and adding an alias to it inside the documentation.

> [!Important]
> This is a joke PR, I hope you had a laugh and a wonderful day <3.

And of course, thank you to [cargo-mommy](https://github.com/Gankra/cargo-mommy) for being very encouraging and helping me submit this PR ( ˘ ³˘)❤  mommy is proud ~❤

> [!Note]
> This builds on to of #6 so you might have merge conflicts if you try to merge them