### PR TITLE
feat: allow specifying custom domains

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -13,7 +13,7 @@ use reqwest::{
 use serde::{Deserialize, Serialize};
 
 /// A domain (as in part of a URL)
-type Domain = String;
+pub type Domain = String;
 
 /// A client for The Abyss
 ///
@@ -121,8 +121,8 @@ impl Gazenot {
     pub fn into_my_custom_abyss(
         source_host: impl Into<SourceHost>,
         owner: impl Into<Owner>,
-        api_server: String,
-        hosting_server: String,
+        api_server: impl Into<Domain>,
+        hosting_server: impl Into<Domain>,
     ) -> Result<Self> {
         Self::new_with_custom_servers(source_host, owner, api_server, hosting_server)
     }
@@ -158,8 +158,8 @@ impl Gazenot {
     pub fn new_with_custom_servers(
         source_host: impl Into<SourceHost>,
         owner: impl Into<Owner>,
-        api_server: String,
-        hosting_server: String,
+        api_server: impl Into<Domain>,
+        hosting_server: impl Into<Domain>,
     ) -> Result<Self> {
         let source_host = source_host.into();
         let owner = owner.into();
@@ -171,8 +171,8 @@ impl Gazenot {
             source_host,
             owner,
             auth_headers,
-            Some(api_server),
-            Some(hosting_server),
+            Some(api_server.into()),
+            Some(hosting_server.into()),
         )
     }
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,4 +1,4 @@
-use std::{str::FromStr, sync::Arc};
+use std::{env, str::FromStr, sync::Arc};
 
 use crate::{
     error::*, AnnouncementKey, ArtifactSet, ArtifactSetId, Owner, PackageName, Release, ReleaseKey,
@@ -158,6 +158,10 @@ impl Gazenot {
         const API_SERVER: &str = "axo-abyss.fly.dev";
         const HOSTING_SERVER: &str = "artifacts.axodotdev.host";
 
+        let api_server = env::var("GAZENOT_API_SERVER").unwrap_or(API_SERVER.to_owned());
+        let hosting_server =
+            env::var("GAZENOT_HOSTING_SERVER").unwrap_or(HOSTING_SERVER.to_owned());
+
         let timeout = std::time::Duration::from_secs(10);
         let client = Client::builder()
             .timeout(timeout)
@@ -165,8 +169,8 @@ impl Gazenot {
             .map_err(|e| GazenotError::new(DESC, e))?;
 
         Ok(Self(Arc::new(GazenotInner {
-            api_server: API_SERVER.to_owned(),
-            hosting_server: HOSTING_SERVER.to_owned(),
+            api_server,
+            hosting_server,
             owner,
             source_host,
             auth_headers,


### PR DESCRIPTION
This allows specifying custom API and hosting domains via two methods:

1. Via the environment, using `GAZENOT_API_SERVER` and `GAZENOT_HOSTING_SERVER`.
2. Via parameters with the new `Gazenot::into_my_custom_abyss`/`Gazenot::new_with_custom_servers` entrypoints. I made these new methods to avoid cluttering up the signature of the old ones for the majority case of callers who don't need to care about this.

In terms of priorities, they take precedence in the following order:

1. Parameters
2. Environment variables
3. Constants