### PR TITLE
feat: implement list endpoint data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 Cargo.lock
+.idea/

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -141,11 +141,34 @@ pub struct AnnouncementKey {
 }
 
 /// A listing of the releases for a package
-///
-/// CURRENTLY A STUB, TBD
 #[derive(Debug, Clone)]
 pub struct ReleaseList {
     /// Name of the package
-    pub package: PackageName,
-    // TBD
+    pub package_name: PackageName,
+    /// Name of the release
+    pub name: String,
+    /// Tag name used for the release
+    pub tag_name: ReleaseTag,
+    /// Version of the release
+    pub version: UnparsedVersion,
+    /// Body of the release announcement
+    pub body: String,
+    /// Whether the release is considered a prerelease
+    pub prerelease: bool,
+    /// Timestamp when the release was announced
+    /// TODO: Verify this is actually the _announcement_ timestamp
+    pub created_at: String,
+    /// List of assets associated with the release
+    pub assets: Vec<ReleaseAsset>,
+}
+
+/// A single release artifact/asset
+#[derive(Debug, Clone)]
+pub struct ReleaseAsset {
+    /// The URL that can be used to download this package
+    pub browser_download_url: String,
+    /// The filename of the asset
+    pub name: String,
+    /// The date it was uploaded and attached to the artifact set
+    pub uploaded_at: String,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -145,6 +145,13 @@ pub struct AnnouncementKey {
 pub struct ReleaseList {
     /// Name of the package
     pub package_name: PackageName,
+    /// The list of releases
+    pub releases: Vec<PublicRelease>,
+}
+
+/// A release that has been announced.
+#[derive(Debug, Clone)]
+pub struct PublicRelease {
     /// Name of the release
     pub name: String,
     /// Tag name used for the release


### PR DESCRIPTION
This makes the list endpoint work. I'm not sure how separated we're keeping "incoming" data (that has to be deserialized) from "outgoing" data (that gets passed to the library user), so I ended up making the two data structs almost identical, for verbosity's sake.