### PR TITLE
fix: minimum axoasset version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ miette = { version = "7.2.0" }
 schemars = "0.8.11"
 
 # things needed for the full client
-axoasset = { version = ">=0.9.0, <0.11.0", features = ["json-serde", "remote"], optional = true }
+axoasset = { version = ">=0.10.1, <0.11.0", features = ["json-serde", "remote"], optional = true }
 url = { version = "2.5.1", features = ["serde"], optional = true }
 tracing = { version = "0.1.36", features = ["log"], optional = true }
 tokio = { version = "1.12.0", features = ["full"], optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ schemars = "0.8.11"
 
 # things needed for the full client
 axoasset = { version = ">=0.10.1, <0.11.0", features = ["json-serde", "remote"], optional = true }
-url = { version = "2.5.1", features = ["serde"], optional = true }
+url = { version = "2.5.0", features = ["serde"], optional = true }
 tracing = { version = "0.1.36", features = ["log"], optional = true }
 tokio = { version = "1.12.0", features = ["full"], optional = true }
 camino = { version = "1.1.6", optional = true }


### PR DESCRIPTION
Now that we're using the reqwest from axoasset, the minimum axoasset is 0.10.1.